### PR TITLE
fix: limit vxe-table dependency to version 3.8.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "vuescroll": "^4.17.3",
     "vuex": "^3.6.0",
     "vuex-electron-store": "^1.4.26",
-    "vxe-table": "^3.4.5",
+    "vxe-table": "~3.8.25",
     "xe-utils": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[Vxe Table 版本升级指南](https://vxetable.cn/v3.8/#/table/start/upgrade)
v3.9+ 分离为纯表格 和 UI组件，升级版本，内部代码不需要改动，需调整安装方式及全局变量。

[Vxe Table 开发指南](https://vxetable.cn/v3.8/#/table/start/install)
需要注意：v3.0.x 可以直接升级 v3.8.x
需要注意：v3.8.x 不能直接升级 v3.9+，需要调整安装方式，如果是使用老版本记得锁定版本号

如果不固定最大版本，yarn会安装v3.12.0，导致table无法渲染。